### PR TITLE
Cпринт №27:

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,11 +4,12 @@ plugins {
     alias(libs.plugins.parcelize)
     alias(libs.plugins.ksp)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
     namespace = "com.practicum.playlistmaker"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.practicum.playlistmaker"
@@ -39,12 +40,20 @@ android {
 
     buildFeatures {
         viewBinding = true
+        compose = true
     }
 }
 
 dependencies {
-    //implementation(platform("com.google.firebase:firebase-bom:33.12.0"))
-    //implementation("com.google.firebase:firebase-analytics")
+    implementation (libs.koin.androidx.compose)
+    implementation("io.coil-kt.coil3:coil-compose:3.2.0")
+    implementation("io.coil-kt.coil3:coil-network-okhttp:3.2.0")
+    implementation(libs.androidx.runtime.livedata)
+    implementation(libs.androidx.material3.android)
+    debugImplementation(libs.androidx.compose.uitool)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.activity)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
     implementation(libs.coroutines)

--- a/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/FavoriteTrackScreen.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/FavoriteTrackScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -42,7 +43,7 @@ fun FavoriteTrackScreen(
         when (trackListState) {
             is FavoriteStatus.Loading -> Empty()
             is FavoriteStatus.Empty -> Empty()
-            is FavoriteStatus.Favorites -> TrackList((trackListState as FavoriteStatus.Favorites).tracks, onClick)
+            is FavoriteStatus.Favorites -> TrackList((trackListState as? FavoriteStatus.Favorites)?.tracks, onClick)
 
         }
     }
@@ -68,20 +69,24 @@ private fun Empty() {
             fontFamily = yandexSansFamily,
             fontWeight = FontWeight.Medium,
             fontSize = 19.sp,
-            modifier = Modifier.padding(top = 16.dp)
+            modifier = Modifier.padding(top = 16.dp),
+            color = colorResource(id = R.color.toolbar)
+
         )
     }
 }
 
 @Composable
-fun TrackList(trackList: List<Track>, onClick:(Track)-> Unit) {
+fun TrackList(trackList: List<Track>?, onClick:(Track)-> Unit) {
     Column(
         modifier = Modifier
             .padding(vertical = 20.dp)
     ) {
 
-        for (track in trackList){
-            TrackPosition(track, onClick)
+        if (trackList != null) {
+            for (track in trackList){
+                TrackPosition(track, onClick)
+            }
         }
 
     }

--- a/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/FavoriteTrackScreen.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/FavoriteTrackScreen.kt
@@ -1,0 +1,106 @@
+package com.practicum.playlistmaker.media.ui.compose
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.media.ui.FavoriteStatus
+import com.practicum.playlistmaker.media.ui.view_model.FavoriteTracksViewModel
+import com.practicum.playlistmaker.search.domain.models.Track
+import com.practicum.playlistmaker.search.ui.compose.modules.TrackPosition
+import com.practicum.playlistmaker.util.yandexSansFamily
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun FavoriteTrackScreen(
+    //viewModel: FavoriteTracksViewModel,
+    onClick:(Track)-> Unit) {
+
+    val viewModel: FavoriteTracksViewModel = koinViewModel()
+   val trackListState by viewModel.observeState().observeAsState()
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+
+
+        when (trackListState) {
+            is FavoriteStatus.Loading -> Empty()
+            is FavoriteStatus.Empty -> Empty()
+            is FavoriteStatus.Favorites -> TrackList((trackListState as FavoriteStatus.Favorites).tracks, onClick)
+
+        }
+    }
+}
+
+@Composable
+private fun Empty() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 106.dp)
+    ) {
+        Image(
+            modifier = Modifier.padding(top = 33.dp),
+            painter = painterResource(id = R.drawable.search_404),
+            contentDescription = null,
+            alignment = Alignment.TopCenter
+        )
+        Text(
+            text = stringResource(id = R.string.media_fragment_favorites_empty),
+            textAlign = TextAlign.Center,
+            fontFamily = yandexSansFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 19.sp,
+            modifier = Modifier.padding(top = 16.dp)
+        )
+    }
+}
+
+@Composable
+fun TrackList(trackList: List<Track>, onClick:(Track)-> Unit) {
+    Column(
+        modifier = Modifier
+            .padding(vertical = 20.dp)
+    ) {
+
+        for (track in trackList){
+            TrackPosition(track, onClick)
+        }
+
+    }
+}
+
+@Preview
+@Composable
+private fun MyPreview(){
+    TrackPosition(
+        Track(
+           trackId= "",
+       trackName= "SuperDuper Song Ever made EGTgkjnsdfghndfognsoaldj",
+   artistName= "ABOABABOABABOABABOABABOABABOABABOABABOABABOABABOAB",
+   trackTime= "08:30",
+   artworkUrl100= "",
+   releaseDate= "",
+   primaryGenreName= "",
+   country= "",
+   collectionName= "",
+   previewUrl= "",
+        ), {})
+}

--- a/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/PlaylistListScreen.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/PlaylistListScreen.kt
@@ -1,0 +1,188 @@
+package com.practicum.playlistmaker.media.ui.compose
+
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.media.domain.model.PlaylistModel
+import com.practicum.playlistmaker.media.ui.view_model.PlaylistListViewModel
+import com.practicum.playlistmaker.util.yandexSansFamily
+import androidx.core.net.toUri
+import com.practicum.playlistmaker.util.Declination
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun PlaylistListScreen(
+    onPlaylistClick: (PlaylistModel) -> Unit,
+    onButtonClick: () -> Unit,
+) {
+
+    val viewModel: PlaylistListViewModel = koinViewModel()
+    val scrollState = rememberScrollState()
+    val playlistState by viewModel.observeState().observeAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 24.dp, bottom = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Button(
+            onClick = {onButtonClick()},
+            enabled = true,
+            shape = RoundedCornerShape(54.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.toolbar))
+        ) {
+            Text(
+                text = "Новый плейлист",
+                fontFamily = yandexSansFamily,
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                color = colorResource(id = R.color.theme_white_black)
+                )
+        }
+
+        if (playlistState.isNullOrEmpty()) {
+            Empty()
+        } else {
+            ListPlaylist(
+                scrollState = scrollState,
+                list = playlistState!!,
+                onPlaylistClick = onPlaylistClick
+            )
+        }
+
+
+    }
+}
+
+@Composable
+private fun Empty() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            modifier = Modifier.padding(top = 33.dp),
+            painter = painterResource(id = R.drawable.search_404),
+            contentDescription = null,
+            alignment = Alignment.TopCenter
+        )
+        Text(
+            text = stringResource(id = R.string.media_fragment_playlist_empty),
+            textAlign = TextAlign.Center,
+            fontFamily = yandexSansFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 19.sp,
+            color = colorResource(id = R.color.toolbar)
+        )
+    }
+}
+
+@Composable
+private fun ListPlaylist(
+    scrollState: ScrollState,
+    list: List<PlaylistModel>,
+    onPlaylistClick: (PlaylistModel) -> Unit,
+) {
+    LazyVerticalGrid(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        columns = GridCells.Fixed(2),
+    ) {
+        items(list) { playlist ->
+            Playlist(
+                playlist = playlist,
+                onPlaylistClick = onPlaylistClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun Playlist(
+    playlist: PlaylistModel,
+    onPlaylistClick: (PlaylistModel) -> Unit
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.padding(bottom = 16.dp)
+        .clickable(true) { onPlaylistClick(playlist) }
+    ) {
+        Column {
+
+            if (playlist.path != ""){
+                AsyncImage(
+                    model = playlist.path.toUri(),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(160.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Image(
+                    painter = painterResource(id = R.drawable.playlist_view_placeholder),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(160.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+
+            Text(
+                textAlign = TextAlign.Start,
+                modifier = Modifier.padding(top = 4.dp),
+                text = playlist.name,
+                fontFamily = yandexSansFamily,
+                fontWeight = FontWeight.Normal,
+                fontSize = 12.sp,
+                color = colorResource(id = R.color.toolbar)
+            )
+            Text(
+                text = "${playlist.tracks.size} ${Declination.getTracks(playlist.tracks.size)}",
+                fontFamily = yandexSansFamily,
+                fontWeight = FontWeight.Normal,
+                fontSize = 12.sp,
+                color = colorResource(id = R.color.toolbar)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/PlaylistListScreen.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/media/ui/compose/PlaylistListScreen.kt
@@ -77,14 +77,16 @@ fun PlaylistListScreen(
                 )
         }
 
-        if (playlistState.isNullOrEmpty()) {
-            Empty()
-        } else {
-            ListPlaylist(
-                scrollState = scrollState,
-                list = playlistState!!,
-                onPlaylistClick = onPlaylistClick
-            )
+        playlistState?.let {
+            if (playlistState.isNullOrEmpty()) {
+                Empty()
+            } else {
+                ListPlaylist(
+                    scrollState = scrollState,
+                    list = it,
+                    onPlaylistClick = onPlaylistClick
+                )
+            }
         }
 
 

--- a/app/src/main/java/com/practicum/playlistmaker/media/ui/fragments/FavoriteTracksFragment.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/media/ui/fragments/FavoriteTracksFragment.kt
@@ -4,118 +4,49 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.practicum.playlistmaker.R
-import com.practicum.playlistmaker.databinding.FragmentFavoriteBinding
-import com.practicum.playlistmaker.media.ui.FavoriteStatus
-import com.practicum.playlistmaker.media.ui.adapters.FavoriteAdapter
+import com.practicum.playlistmaker.media.ui.compose.FavoriteTrackScreen
 import com.practicum.playlistmaker.media.ui.view_model.FavoriteTracksViewModel
 import com.practicum.playlistmaker.search.domain.models.Track
 import com.practicum.playlistmaker.search.ui.fragment.SearchFragment.Companion.TRACK_BUNDLE
-import com.practicum.playlistmaker.util.debounce
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class FavoriteTracksFragment : Fragment() {
 
     companion object {
         fun newInstance() = FavoriteTracksFragment()
-        private const val CLICK_DEBOUNCE_DELAY = 1000L
     }
-
-    private var _binding: FragmentFavoriteBinding? = null
-    private val binding get() = _binding!!
 
     private val favoriteViewModel: FavoriteTracksViewModel by viewModel()
 
-    private var adapterFavorites = FavoriteAdapter { item ->
-        onTrackClick(item)
-    }
-
-    private var isClickAllowed = true
-
-    private val clickDebounce =
-        debounce<Boolean>(CLICK_DEBOUNCE_DELAY, lifecycleScope, false) { allowed ->
-            isClickAllowed = allowed
-        }
 
     private fun onTrackClick(track: Track) {
-        if (clickDebounce()) {
-            adapterFavorites.notifyDataSetChanged()
             findNavController().navigate(
                 R.id.action_mediaFragment_to_playerFragment,
                 bundleOf(TRACK_BUNDLE to track)
             )
         }
-    }
-
-    private fun clickDebounce(): Boolean {
-        val current = isClickAllowed
-        if (isClickAllowed) {
-            isClickAllowed = false
-            clickDebounce(true)
-        }
-        return current
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentFavoriteBinding.inflate(inflater, container, false)
-
-        return binding.root
+        return ComposeView(requireContext()).apply {
+            setContent {
+                FavoriteTrackScreen(
+                    //viewModel = favoriteViewModel,
+                    {track -> onTrackClick(track)})
+            }
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        favoriteViewModel.observeState().observe(viewLifecycleOwner) {
-            render(it)
-        }
-
-        binding.fragmentFavoriteContent.layoutManager = LinearLayoutManager(requireContext())
-        binding.fragmentFavoriteContent.adapter = adapterFavorites
-
         favoriteViewModel.getFavorites()
-
     }
 
-    private fun render(state: FavoriteStatus) {
-        when (state) {
-            is FavoriteStatus.Loading -> showProgressBar()
-            is FavoriteStatus.Empty -> showEmpty()
-            is FavoriteStatus.Favorites -> showContent(state.tracks)
-        }
-    }
-
-    private fun showContent(tracks: List<Track>) {
-        if (tracks.isEmpty()) {
-            showEmpty()
-        } else {
-            adapterFavorites.favoriteTracks.clear()
-            adapterFavorites.favoriteTracks.addAll(tracks)
-            adapterFavorites.favoriteTracks.reverse()
-            adapterFavorites.notifyDataSetChanged()
-            binding.favoriteProgressBar.isVisible = false
-            binding.fragmentFavoriteContent.isVisible = true
-            binding.fragmentFavoriteEmpty.isVisible = false
-        }
-    }
-
-    private fun showProgressBar() {
-        binding.favoriteProgressBar.isVisible = true
-        binding.fragmentFavoriteContent.isVisible = false
-        binding.fragmentFavoriteEmpty.isVisible = false
-    }
-
-    private fun showEmpty() {
-        binding.favoriteProgressBar.isVisible = false
-        binding.fragmentFavoriteContent.isVisible = false
-        binding.fragmentFavoriteEmpty.isVisible = true
-    }
 }

--- a/app/src/main/java/com/practicum/playlistmaker/media/ui/fragments/PlaylistListFragment.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/media/ui/fragments/PlaylistListFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -14,6 +15,7 @@ import com.practicum.playlistmaker.R
 import com.practicum.playlistmaker.databinding.FragmentPlaylistListBinding
 import com.practicum.playlistmaker.media.domain.model.PlaylistModel
 import com.practicum.playlistmaker.media.ui.adapters.FullscreenPlaylistAdapter
+import com.practicum.playlistmaker.media.ui.compose.PlaylistListScreen
 import com.practicum.playlistmaker.media.ui.view_model.PlaylistListViewModel
 import com.practicum.playlistmaker.util.debounce
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -22,34 +24,10 @@ class PlaylistListFragment : Fragment() {
 
     companion object {
         fun newInstance() = PlaylistListFragment()
-        private const val CLICK_DEBOUNCE_DELAY = 1000L
         const val PLAYLIST_BUNDLE = "playlist"
     }
 
-    private var _binding: FragmentPlaylistListBinding? = null
-    private val binding get() = _binding!!
-
     private val viewModel: PlaylistListViewModel by viewModel()
-
-    private var adapterPlaylists = FullscreenPlaylistAdapter { item ->
-        onPlaylistClick(item)
-    }
-
-    private var isClickAllowed = true
-
-    private val clickDebounce =
-        debounce<Boolean>(CLICK_DEBOUNCE_DELAY, lifecycleScope, false) { allowed ->
-            isClickAllowed = allowed
-        }
-
-    private fun onPlaylistClick(playlistModel: PlaylistModel) {
-        if (clickDebounce()) {
-            findNavController().navigate(
-                R.id.action_mediaFragment_to_playlistFragment,
-                bundleOf(PLAYLIST_BUNDLE to playlistModel)
-            )
-        }
-    }
 
     override fun onResume() {
         super.onResume()
@@ -58,49 +36,32 @@ class PlaylistListFragment : Fragment() {
         }
     }
 
-    private fun clickDebounce(): Boolean {
-        val current = isClickAllowed
-        if (isClickAllowed) {
-            isClickAllowed = false
-            clickDebounce(true)
-        }
-        return current
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentPlaylistListBinding.inflate(inflater, container, false)
+        return ComposeView(requireContext()).apply {
+            setContent {
+                PlaylistListScreen(
+                    onPlaylistClick = { playlistModel ->
+                        findNavController().navigate(
+                            R.id.action_mediaFragment_to_playlistFragment,
+                            bundleOf(PLAYLIST_BUNDLE to playlistModel)
+                        )
+                    },
+                    onButtonClick = {
+                        findNavController().navigate(
+                            R.id.action_mediaFragment_to_newPlaylistFragment,
+                        )
+                    }
 
-        return binding.root
+                )
+            }
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.mediaButtonNewPlaylist.setOnClickListener {
-            findNavController().navigate(
-                R.id.action_mediaFragment_to_newPlaylistFragment,
-            )
-        }
-
-        binding.mediaRecyclerView.layoutManager =
-            GridLayoutManager(requireContext(), 2, GridLayoutManager.VERTICAL, false)
-        binding.mediaRecyclerView.adapter = adapterPlaylists
-
-        viewModel.observeState().observe(viewLifecycleOwner) {
-            if (it.size == 0) {
-                binding.mediaRecyclerView.isVisible = false
-                binding.mediaNoPlaylists.isVisible = true
-            } else {
-                adapterPlaylists.playlistList.clear()
-                adapterPlaylists.playlistList.addAll(it)
-                adapterPlaylists.notifyDataSetChanged()
-                binding.mediaRecyclerView.isVisible = true
-                binding.mediaNoPlaylists.isVisible = false
-            }
-        }
-
         viewModel.getPlaylists()
     }
 

--- a/app/src/main/java/com/practicum/playlistmaker/media/ui/view_model/FavoriteTracksViewModel.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/media/ui/view_model/FavoriteTracksViewModel.kt
@@ -20,7 +20,12 @@ class FavoriteTracksViewModel(
             favoriteTrackInteractor
                 .getFavoriteTrack()
                 .collect { tracks ->
-                    stateLiveData.value = FavoriteStatus.Favorites(tracks)
+
+                    if (tracks.isNullOrEmpty()){
+                        stateLiveData.value = FavoriteStatus.Empty
+                    } else {
+                        stateLiveData.value = FavoriteStatus.Favorites(tracks)
+                    }
                 }
         }
     }

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/SearchScreen.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/SearchScreen.kt
@@ -1,0 +1,94 @@
+package com.practicum.playlistmaker.search.ui.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.practicum.playlistmaker.search.domain.models.Track
+import com.practicum.playlistmaker.search.ui.compose.modules.History
+import com.practicum.playlistmaker.search.ui.compose.modules.Loading
+import com.practicum.playlistmaker.search.ui.compose.modules.NoConnection
+import com.practicum.playlistmaker.search.ui.compose.modules.NotFound
+import com.practicum.playlistmaker.search.ui.compose.modules.SearchField
+import com.practicum.playlistmaker.search.ui.compose.modules.SearchResult
+import com.practicum.playlistmaker.search.ui.models.SearchStatus
+import com.practicum.playlistmaker.search.ui.view_model.SearchViewModel
+import kotlinx.coroutines.delay
+
+
+@Composable
+fun SearchScreen(
+    viewModel: SearchViewModel,
+    onClick: (Track) -> Unit
+) {
+
+    //scroll
+    val scrollState = rememberScrollState()
+
+    //states
+    val screenState by viewModel.observeState().observeAsState()
+
+
+    //show keyboard
+    val showKeyboard = remember { mutableStateOf(true) }
+    val focusRequester = remember { FocusRequester() }
+    val keyboard = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(focusRequester) {
+        if (showKeyboard.equals(true)) {
+            focusRequester.requestFocus()
+            delay(100)
+            keyboard?.show()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        SearchField(focusRequester, viewModel, keyboard!!)
+
+        when (screenState) {
+            SearchStatus.Clean -> {
+
+            }
+
+            SearchStatus.Error -> NoConnection(viewModel = viewModel)
+            SearchStatus.Loading -> Loading()
+            is SearchStatus.Content -> {
+                SearchResult(
+                    scrollState = scrollState,
+                    trackList = (screenState as SearchStatus.Content).tracks,
+                    onClick = onClick,
+                )
+            }
+
+            SearchStatus.Empty -> NotFound()
+            is SearchStatus.History -> {
+                History(
+                    scrollState = scrollState,
+                    trackList = (screenState as SearchStatus.History).historyTracks,
+                    onClickHistory = onClick,
+                    viewModel = viewModel
+                )
+            }
+
+            null -> {}
+        }
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/SearchScreen.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/SearchScreen.kt
@@ -48,7 +48,7 @@ fun SearchScreen(
     val keyboard = LocalSoftwareKeyboardController.current
 
     LaunchedEffect(focusRequester) {
-        if (showKeyboard.equals(true)) {
+        if (showKeyboard.value) {
             focusRequester.requestFocus()
             delay(100)
             keyboard?.show()
@@ -61,7 +61,7 @@ fun SearchScreen(
             .padding(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        SearchField(focusRequester, viewModel, keyboard!!)
+        SearchField(focusRequester, viewModel, keyboard)
 
         when (screenState) {
             SearchStatus.Clean -> {

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/History.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/History.kt
@@ -3,6 +3,7 @@ package com.practicum.playlistmaker.search.ui.compose.modules
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -29,42 +30,49 @@ fun History(
     viewModel: SearchViewModel
 ) {
 
-    Column(
+    LazyColumn(
         modifier = Modifier
-            .padding(top = 16.dp)
-            .verticalScroll(scrollState),
+            .padding(top = 16.dp),
+        //.verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text(
-            text = stringResource(id = R.string.search_history),
-            fontFamily = yandexSansFamily,
-            fontWeight = FontWeight.Medium,
-            fontSize = 19.sp,
-            modifier = Modifier.padding(top = 18.dp, bottom = 12.dp),
-            color = colorResource(id = R.color.toolbar)
-        )
-        for (track in trackList) {
-            TrackPosition(track, onClickHistory)
-        }
-
-        Button(
-            modifier = Modifier.padding(top = 24.dp),
-            onClick = {
-                viewModel.clearHistory()
-            },
-            enabled = true,
-            shape = RoundedCornerShape(54.dp),
-            colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.toolbar))
-        ) {
+        items(1) {
             Text(
-                text = stringResource(id = R.string.search_clear_history),
+                text = stringResource(id = R.string.search_history),
                 fontFamily = yandexSansFamily,
                 fontWeight = FontWeight.Medium,
-                fontSize = 14.sp,
-                color = colorResource(id = R.color.theme_white_black)
+                fontSize = 19.sp,
+                modifier = Modifier.padding(top = 18.dp, bottom = 12.dp),
+                color = colorResource(id = R.color.toolbar)
+            )
+        }
+
+
+        items(trackList.size) {
+            TrackPosition(trackList[it], onClickHistory)
+        }
+
+        items(1) {
+            Button(
+                modifier = Modifier.padding(top = 24.dp),
+                onClick = {
+                    viewModel.clearHistory()
+                },
+                enabled = true,
+                shape = RoundedCornerShape(54.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.toolbar))
+            ) {
+                Text(
+                    text = stringResource(id = R.string.search_clear_history),
+                    fontFamily = yandexSansFamily,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 14.sp,
+                    color = colorResource(id = R.color.theme_white_black)
 
                 )
+            }
         }
+
 
     }
 }

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/History.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/History.kt
@@ -1,0 +1,70 @@
+package com.practicum.playlistmaker.search.ui.compose.modules
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.search.domain.models.Track
+import com.practicum.playlistmaker.search.ui.view_model.SearchViewModel
+import com.practicum.playlistmaker.util.yandexSansFamily
+
+@Composable
+fun History(
+    scrollState: ScrollState,
+    trackList: List<Track>,
+    onClickHistory: (Track) -> Unit,
+    viewModel: SearchViewModel
+) {
+
+    Column(
+        modifier = Modifier
+            .padding(top = 16.dp)
+            .verticalScroll(scrollState),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(id = R.string.search_history),
+            fontFamily = yandexSansFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 19.sp,
+            modifier = Modifier.padding(top = 18.dp, bottom = 12.dp),
+            color = colorResource(id = R.color.toolbar)
+        )
+        for (track in trackList) {
+            TrackPosition(track, onClickHistory)
+        }
+
+        Button(
+            modifier = Modifier.padding(top = 24.dp),
+            onClick = {
+                viewModel.clearHistory()
+            },
+            enabled = true,
+            shape = RoundedCornerShape(54.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.toolbar))
+        ) {
+            Text(
+                text = stringResource(id = R.string.search_clear_history),
+                fontFamily = yandexSansFamily,
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                color = colorResource(id = R.color.theme_white_black)
+
+                )
+        }
+
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/Loading.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/Loading.kt
@@ -1,0 +1,21 @@
+package com.practicum.playlistmaker.search.ui.compose.modules
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.practicum.playlistmaker.R
+
+@Composable
+fun Loading() {
+    CircularProgressIndicator(
+        modifier = Modifier
+            .width(44.dp)
+            .padding(top = 192.dp),
+        color = colorResource(id = R.color.theme_white_black),
+        trackColor = colorResource(id = R.color.blue),
+    )
+}

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/NoConnection.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/NoConnection.kt
@@ -1,0 +1,66 @@
+package com.practicum.playlistmaker.search.ui.compose.modules
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.search.ui.view_model.SearchViewModel
+import com.practicum.playlistmaker.util.yandexSansFamily
+
+@Composable
+fun NoConnection(
+    viewModel: SearchViewModel
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(top = 102.dp)
+    ) {
+        Image(
+            modifier = Modifier.padding(top = 33.dp),
+            painter = painterResource(id = R.drawable.search_no_connect),
+            contentDescription = null,
+            alignment = Alignment.TopCenter
+        )
+        Text(
+            modifier = Modifier.padding(top = 16.dp),
+            text = stringResource(id = R.string.search_no_connection),
+            textAlign = TextAlign.Center,
+            fontFamily = yandexSansFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 19.sp,
+            color = colorResource(id = R.color.toolbar)
+        )
+        Button(
+            modifier = Modifier.padding(top = 24.dp),
+            onClick = {
+                viewModel.searchUpdButtonPressed()
+            },
+            enabled = true,
+            shape = RoundedCornerShape(54.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.toolbar))
+        ) {
+            Text(
+                text = stringResource(id = R.string.search_update),
+                fontFamily = yandexSansFamily,
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                color = colorResource(id = R.color.theme_white_black)
+
+                )
+        }
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/NotFound.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/NotFound.kt
@@ -1,0 +1,42 @@
+package com.practicum.playlistmaker.search.ui.compose.modules
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.util.yandexSansFamily
+
+@Composable
+fun NotFound() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(top = 102.dp)
+    ) {
+        Image(
+            modifier = Modifier.padding(top = 33.dp),
+            painter = painterResource(id = R.drawable.search_404),
+            contentDescription = null,
+            alignment = Alignment.TopCenter
+        )
+        Text(
+            modifier = Modifier.padding(top = 16.dp),
+            text = stringResource(id = R.string.search_404),
+            textAlign = TextAlign.Center,
+            fontFamily = yandexSansFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 19.sp,
+            color = colorResource(id = R.color.toolbar)
+        )
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchField.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchField.kt
@@ -43,7 +43,7 @@ import com.practicum.playlistmaker.util.yandexSansFamily
 fun SearchField(
     focusRequester: FocusRequester,
     viewModel: SearchViewModel,
-    keyboard: SoftwareKeyboardController
+    keyboard: SoftwareKeyboardController?
 ) {
 
     val queryState by viewModel.observeQuery().observeAsState()
@@ -143,8 +143,7 @@ fun SearchField(
                     .wrapContentWidth()
                     .clickable(true) {
                         query = ""
-                        keyboard.hide()
-                        viewModel.getHistory()
+                        keyboard?.hide()
                     }
             )
         }

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchField.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchField.kt
@@ -1,0 +1,154 @@
+package com.practicum.playlistmaker.search.ui.compose.modules
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.search.ui.view_model.SearchViewModel
+import com.practicum.playlistmaker.util.yandexSansFamily
+
+@Composable
+fun SearchField(
+    focusRequester: FocusRequester,
+    viewModel: SearchViewModel,
+    keyboard: SoftwareKeyboardController
+) {
+
+    val queryState by viewModel.observeQuery().observeAsState()
+    var query by remember { mutableStateOf("") }
+    var showHint by remember { mutableStateOf(true) }
+
+    LaunchedEffect (queryState){
+        query = queryState ?: ""
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .background(colorResource(R.color.search_field), RoundedCornerShape(8.dp)),
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.size(36.dp),
+        ) {
+            Icon(
+                tint = colorResource(R.color.gray),
+                painter = painterResource(id = R.drawable.search_search),
+                contentDescription = null,
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .wrapContentHeight(),
+
+                )
+        }
+        Box(
+            modifier = Modifier
+                .weight(1F)
+                .align(Alignment.CenterVertically)
+                .fillMaxWidth()
+                .wrapContentHeight()
+        ) {
+            BasicTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .focusRequester(focusRequester)
+                    .clickable {
+
+                    }
+                    .onFocusEvent { focusState ->
+                        if (focusState.isFocused){
+                            viewModel.getHistory()
+                        }
+
+                    },
+                value = query,
+                onValueChange = { query = it },
+                maxLines = 1,
+                textStyle = TextStyle(
+                    fontFamily = yandexSansFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 16.sp,
+                ),
+                decorationBox = { innerTextField ->
+                    Row {
+                        if (query.isNotEmpty()) {
+                            showHint = false
+                            LaunchedEffect(query) {
+                                viewModel.searchDebounce(query)
+                            }
+                        } else {
+                            showHint = true
+                        }
+                        innerTextField()
+                    }
+                },
+            )
+            if (showHint) {
+                Text(
+                    text = stringResource(R.string.search_name),
+                    fontFamily = yandexSansFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 16.sp,
+                    color = Color.Gray
+                )
+            }
+
+        }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.size(36.dp),
+
+            ) {
+            Icon(
+                tint = colorResource(R.color.gray),
+                painter = painterResource(id = R.drawable.search_clear),
+                contentDescription = null,
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .clickable(true) {
+                        query = ""
+                        keyboard.hide()
+                        viewModel.getHistory()
+                    }
+            )
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchResult.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchResult.kt
@@ -1,0 +1,29 @@
+package com.practicum.playlistmaker.search.ui.compose.modules
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.practicum.playlistmaker.search.domain.models.Track
+
+@Composable
+fun SearchResult(
+    scrollState: ScrollState,
+    trackList: List<Track>,
+    onClick: (Track) -> Unit,
+) {
+
+
+    Column(
+        modifier = Modifier
+            .padding(top = 16.dp)
+            .verticalScroll(scrollState),
+    ) {
+        for (track in trackList) {
+            TrackPosition(track, onClick)
+        }
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchResult.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/SearchResult.kt
@@ -3,6 +3,7 @@ package com.practicum.playlistmaker.search.ui.compose.modules
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,13 +18,12 @@ fun SearchResult(
 ) {
 
 
-    Column(
+    LazyColumn(
         modifier = Modifier
-            .padding(top = 16.dp)
-            .verticalScroll(scrollState),
+            .padding(top = 16.dp),
     ) {
-        for (track in trackList) {
-            TrackPosition(track, onClick)
+        items(trackList.size){
+            TrackPosition(trackList[it], onClick)
         }
     }
 }

--- a/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/TrackPosition.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/search/ui/compose/modules/TrackPosition.kt
@@ -1,0 +1,125 @@
+package com.practicum.playlistmaker.search.ui.compose.modules
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.search.domain.models.Track
+import com.practicum.playlistmaker.util.yandexSansFamily
+
+@Composable
+fun TrackPosition(track: Track, onClick:(Track)-> Unit) {
+    Row(
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .padding(start = 13.dp)
+            .padding(end = 12.dp)
+            .fillMaxWidth()
+            .clickable(enabled = true) { onClick(track) },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+
+        AsyncImage(
+            model = track.artworkUrl100,
+            placeholder = painterResource(id = R.drawable.playlist_view_placeholder),
+            contentDescription = null,
+            modifier = Modifier.size(45.dp)
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1F)
+                .padding(horizontal = 8.dp),
+        ) {
+            Text(
+                text = track.trackName,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontFamily = yandexSansFamily,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                color = colorResource(id = R.color.toolbar)
+            )
+            Row(
+                horizontalArrangement = Arrangement.Start,
+                modifier = Modifier.fillMaxWidth()
+            ){
+                Text(
+                    text = track.artistName,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.wrapContentWidth(),
+                    fontFamily = yandexSansFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 11.sp,
+                    color = colorResource(id = R.color.toolbar)
+
+                )
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.padding(5.dp)
+                        .wrapContentWidth(),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.track_dot),
+                        contentDescription = null,
+                    )
+                }
+                Text(
+                    text = track.trackTime,
+                    maxLines = 1,
+                    fontFamily = yandexSansFamily,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 11.sp,
+                    color = colorResource(id = R.color.toolbar)
+                )
+            }
+
+        }
+
+        Image(
+            painter = painterResource(id = R.drawable.settings_track_arrow_forward),
+            contentDescription = null,
+            alignment = Alignment.CenterEnd,
+        )
+    }
+}
+
+@Preview(device = "id:pixel_5", showSystemUi = false)
+@Composable
+private fun MyPreview(){
+    TrackPosition(
+        Track(
+            trackId= "",
+            trackName= "SuperDuper ",
+            artistName= "ABOABAB",
+            trackTime= "08:30",
+            artworkUrl100= "",
+            releaseDate= "",
+            primaryGenreName= "",
+            country= "",
+            collectionName= "",
+            previewUrl= "",
+        ), {})
+}

--- a/app/src/main/java/com/practicum/playlistmaker/settings/ui/compose/SettingsScreen.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/settings/ui/compose/SettingsScreen.kt
@@ -1,0 +1,156 @@
+package com.practicum.playlistmaker.settings.ui.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.practicum.playlistmaker.R
+import com.practicum.playlistmaker.settings.ui.model.EmailData
+import com.practicum.playlistmaker.settings.ui.view_model.SettingsViewModel
+import com.practicum.playlistmaker.util.App
+import com.practicum.playlistmaker.util.yandexSansFamily
+
+@Composable
+fun SettingsScreen(settingsViewModel: SettingsViewModel) {
+
+    val context = LocalContext.current
+    val checked by settingsViewModel.observeDarkTheme().observeAsState()
+
+    Scaffold(
+        backgroundColor = colorResource(id = R.color.theme_white_black)
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(true) {},
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier
+                        .padding(vertical = 21.dp)
+                        .padding(start = 16.dp),
+                    text = stringResource(id = R.string.settings_button1),
+                    color = colorResource(id = R.color.toolbar),
+                    style = TextStyle(
+                        color = colorResource(id = R.color.toolbar),
+                        fontSize = 16.sp,
+                        fontFamily = yandexSansFamily,
+                        fontWeight = FontWeight.Normal,
+                    )
+                )
+                Switch(
+                    modifier = Modifier.padding(top = 10.dp, end = 6.dp, bottom = 11.dp),
+
+                    checked = checked!!,
+                    onCheckedChange = {
+                        (context.applicationContext as App).switchTheme(it)
+                        settingsViewModel.toggleTheme(it)
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = colorResource(id = R.color.blue),
+                        checkedTrackColor = colorResource(id = R.color.blue_light),
+                        uncheckedThumbColor = colorResource(id = R.color.gray),
+                        uncheckedTrackColor = colorResource(id = R.color.gray_edit_text),
+                    )
+                )
+            }
+
+            MenuElement(
+                name = stringResource(id = R.string.settings_button2),
+                icon = painterResource(id = R.drawable.settings_share),
+                action = {
+                    settingsViewModel.shareApp(
+                        context.getString(R.string.course_url)
+                    )
+                }
+            )
+
+            MenuElement(
+                name = stringResource(id = R.string.settings_button3),
+                icon = painterResource(id = R.drawable.settings_support),
+                action = {
+                    settingsViewModel.getHelp(
+                        EmailData(
+                            email = context.getString(R.string.my_email),
+                            subject = context.getString(R.string.email_subject),
+                            text = context.getString(R.string.email_text),
+                        )
+                    )
+                }
+            )
+
+            MenuElement(
+                name = stringResource(id = R.string.settings_button4),
+                icon = painterResource(id = R.drawable.settings_track_arrow_forward),
+                action = {
+                    settingsViewModel.userAgreement(
+                        context.getString(R.string.practicum_offer)
+                    )
+                }
+            )
+
+        }
+    }
+}
+
+@Composable
+fun MenuElement(name: String, icon: Painter, action: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(true) {
+                action()
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(vertical = 21.dp)
+                .padding(start = 16.dp),
+            text = name,
+            color = colorResource(id = R.color.toolbar),
+            style = TextStyle(
+                color = colorResource(id = R.color.toolbar),
+                fontSize = 16.sp,
+                fontFamily = yandexSansFamily,
+                fontWeight = FontWeight.Normal,
+            ),
+        )
+        Icon(
+            modifier = Modifier.padding(top = 19.dp, end = 12.dp, bottom = 18.dp),
+            painter = icon,
+            contentDescription = null,
+            tint = colorResource(id = R.color.toolbar),
+        )
+
+    }
+}

--- a/app/src/main/java/com/practicum/playlistmaker/settings/ui/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/settings/ui/fragment/SettingsFragment.kt
@@ -6,9 +6,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.Fragment
 import com.practicum.playlistmaker.R
 import com.practicum.playlistmaker.databinding.FragmentSettingsBinding
+import com.practicum.playlistmaker.settings.ui.compose.SettingsScreen
 import com.practicum.playlistmaker.settings.ui.model.EmailData
 import com.practicum.playlistmaker.settings.ui.model.IntentType
 import com.practicum.playlistmaker.settings.ui.view_model.SettingsViewModel
@@ -17,15 +21,17 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class SettingsFragment : Fragment() {
 
-    private lateinit var binding: FragmentSettingsBinding
     private val settingsViewModel: SettingsViewModel by viewModel()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSettingsBinding.inflate(inflater, container, false)
-        return binding.root
+        return ComposeView(requireContext()).apply {
+            setContent {
+                SettingsScreen(settingsViewModel)
+            }
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -35,41 +41,8 @@ class SettingsFragment : Fragment() {
             openActivity(it)
         }
 
-        settingsViewModel.darkThemeLive.observe(viewLifecycleOwner) {
-            binding.themeSwitcher.isChecked = it
-        }
-
         (requireContext().applicationContext as App).checkTheme()
         settingsViewModel.checkDarkTheme((requireContext().applicationContext as App).darkTheme)
-
-
-        binding.themeSwitcher.setOnCheckedChangeListener { _, isChecked ->
-            (requireActivity().applicationContext as App).switchTheme(isChecked)
-            settingsViewModel.toggleTheme(isChecked)
-        }
-
-
-        binding.share.setOnClickListener {
-            settingsViewModel.shareApp(
-                requireContext().getString(R.string.course_url)
-            )
-        }
-
-        binding.support.setOnClickListener {
-            settingsViewModel.getHelp(
-                EmailData(
-                    email = requireContext().getString(R.string.my_email),
-                    subject = requireContext().getString(R.string.email_subject),
-                    text = requireContext().getString(R.string.email_text),
-                )
-            )
-        }
-
-        binding.userAgreement.setOnClickListener {
-            settingsViewModel.userAgreement(
-                requireContext().getString(R.string.practicum_offer)
-            )
-        }
 
     }
 
@@ -112,4 +85,5 @@ class SettingsFragment : Fragment() {
     companion object {
         const val MAIL_TO = "mailto:"
     }
+
 }

--- a/app/src/main/java/com/practicum/playlistmaker/settings/ui/view_model/SettingsViewModel.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/settings/ui/view_model/SettingsViewModel.kt
@@ -13,17 +13,13 @@ class SettingsViewModel(
 ) : ViewModel() {
 
     private val darkThemeLiveMutable = MutableLiveData<Boolean>()
-    val darkThemeLive: LiveData<Boolean> = darkThemeLiveMutable
+    fun observeDarkTheme(): LiveData<Boolean> = darkThemeLiveMutable
+
 
     private val intentLiveDataMutable = MutableLiveData<IntentType>()
     val intentLiveData: LiveData<IntentType> = intentLiveDataMutable
 
     fun checkDarkTheme(systemDarkTheme: Boolean) {
-//        if (settingsInteractor.checkThemeSettings()) {
-//            darkThemeLiveMutable.value = settingsInteractor.getDarkTheme().darkTheme
-//        } else {
-//            darkThemeLiveMutable.value = systemDarkTheme
-//        }
         darkThemeLiveMutable.value = systemDarkTheme
     }
 

--- a/app/src/main/java/com/practicum/playlistmaker/util/FontProvider.kt
+++ b/app/src/main/java/com/practicum/playlistmaker/util/FontProvider.kt
@@ -1,0 +1,16 @@
+package com.practicum.playlistmaker.util
+
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import com.practicum.playlistmaker.R
+
+val yandexSansFamily = FontFamily(
+    Font(R.font.ys_display_bold, FontWeight.Bold),
+    Font(R.font.ys_display_heavy, FontWeight.ExtraBold),
+    Font(R.font.ys_display_light, FontWeight.Light),
+    Font(R.font.ys_display_medium, FontWeight.Medium),
+    Font(R.font.ys_display_regular, FontWeight.Normal),
+    Font(R.font.ys_display_thin, FontWeight.Thin),
+
+)

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,7 @@
     <color name="black">#1A1B22</color>
     <color name="white">#FFFFFF</color>
     <color name="blue">#3772E7</color>
+    <color name="blue_light">#9FBBF3</color>
     <color name="deep_black">#000000</color>
     <color name="gray">#AEAFB4</color>
     <color name="gray_edit_text">#E6E8EB</color>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,26 +1,31 @@
 [versions]
 agp = "8.6.1"
-kotlin = "2.0.0"
-coreKtx = "1.10.1"
+kotlin = "2.0.21"
+coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
-material = "1.8.0"
-activity = "1.8.0"
-constraintlayout = "2.1.4"
-fragmentKtx = "1.5.6"
+material = "1.12.0"
+activity = "1.10.1"
+constraintlayout = "2.2.1"
+fragmentKtx = "1.8.7"
 viewpager2 = "1.1.0"
-navigationFragmentKtx = "2.5.3"
+navigationFragmentKtx = "2.9.0"
 glide = "4.14.2"
 koin = "3.3.0"
 retrofit = "2.9.0"
-coroutines = "1.6.4"
+coroutines = "1.9.0"
 roomKtx = "2.5.1"
 roomCompiler = "2.5.1"
 roomRuntime = "2.5.1"
-fireBom = "33.12.0"
+fireBom = "33.14.0"
 playServicesMeasurementApi = "22.4.0"
+composeUiMatrial = "1.8.2"
+composeActivity = "1.10.1"
+runtimeLivedata = "1.8.2"
+material3Android = "1.3.2"
+koinAndroidxCompose ="3.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -46,6 +51,14 @@ androidx-room-runtime = { group = "androidx.room", name = "room-runtime", versio
 firebase-analytics = {group = "com.google.firebase", name = "firebase-analytics"}
 firebase-bom = {group = "com.google.firebase", name = "firebase-bom", version.ref = "fireBom"}
 play-services-measurement-api = { group = "com.google.android.gms", name = "play-services-measurement-api", version.ref = "playServicesMeasurementApi" }
+androidx-compose-ui = {group = "androidx.compose.ui", name = "ui", version.ref = "composeUiMatrial"}
+androidx-compose-material = {group = "androidx.compose.material", name = "material", version.ref = "composeUiMatrial"}
+androidx-compose-activity = {group = "androidx.activity", name = "activity-compose", version.ref = "composeActivity"}
+androidx-compose-uitool = {group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUiMatrial"}
+androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
+androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koinAndroidxCompose" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -53,3 +66,4 @@ jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = 
 parcelize = { id = "kotlin-parcelize" }
 ksp = { id = "com.google.devtools.ksp" }
 google-services = { id = "com.google.gms.google-services"}
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Выбран Уровень 1. Замена UI нескольких экранов на Compose с сохранением традиционного подхода к навигации
1. Заменены UI с View на Compose для следующих экранов приложения: «Поиск» (поиск треков и история поиска). «Медиатека». «Настройки».